### PR TITLE
Add PEFT dependency for Transformers 5 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 diffusers>=0.25.0
+peft>=0.18.0
 accelerate>=0.20.0
 opencv-python>=4.0.0
 scikit-learn>=1.0.0


### PR DESCRIPTION
This adds an explicit PEFT dependency to fix an import failure seen in newer Hugging Face / ComfyUI environments:

`cannot import name 'HybridCache' from 'transformers'`

The failure can occur through the diffusers LoRA import path when Transformers 5.x is installed with an older PEFT version. PEFT 0.18.0+ is required for Transformers 5 compatibility.

This repo already depends on `bitsandbytes>=0.49.2`, which effectively requires Python 3.10+, so adding `peft>=0.18.0` should not introduce a new Python-version floor beyond the existing dependency set.

Tested locally in ComfyUI with:

- diffusers 0.35.2
- Transformers 5.9
- PEFT 0.19.1

Verification:
- ComfyUI starts successfully
- ComfyUI-See-through loads without the `HybridCache` import error